### PR TITLE
Add requests import for API routes

### DIFF
--- a/movie_lottery/routes/api_routes.py
+++ b/movie_lottery/routes/api_routes.py
@@ -1,5 +1,6 @@
 # F:\GPT\movie-lottery V2\movie_lottery\routes\api_routes.py
 import random
+import requests
 from flask import Blueprint, request, jsonify, url_for, current_app
 from qbittorrentapi import Client, exceptions as qbittorrent_exceptions
 


### PR DESCRIPTION
## Summary
- add the missing requests import in api_routes so RequestException can be referenced

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1363a47f0832898a7bdbab36bf194