### PR TITLE
Add background magnet search and integrate with UI

### DIFF
--- a/movie_lottery/static/js/api/movies.js
+++ b/movie_lottery/static/js/api/movies.js
@@ -109,3 +109,36 @@ export async function saveMagnetLink(kinopoiskId, magnetLink) {
     if (!response.ok) throw new Error('Ошибка сети при сохранении magnet-ссылки.');
     return await response.json();
 }
+
+/**
+ * Запускает поиск magnet-ссылки на сервере.
+ * @param {number|string} kinopoiskId - ID фильма на Кинопоиске.
+ * @param {object} payload - Дополнительные параметры поиска.
+ * @returns {Promise<object>} - Текущий статус задачи.
+ */
+export async function startMagnetSearch(kinopoiskId, payload = {}) {
+    const response = await fetch(`/api/search-magnet/${kinopoiskId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.message || 'Не удалось запустить поиск magnet-ссылки.');
+    }
+    return await response.json();
+}
+
+/**
+ * Получает текущий статус фонового поиска magnet-ссылки.
+ * @param {number|string} kinopoiskId - ID фильма на Кинопоиске.
+ * @returns {Promise<object>} - Статус задачи.
+ */
+export async function fetchMagnetSearchStatus(kinopoiskId) {
+    const response = await fetch(`/api/search-magnet/${kinopoiskId}`);
+    if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.message || 'Не удалось получить статус поиска magnet.');
+    }
+    return await response.json();
+}

--- a/movie_lottery/static/js/pages/history.js
+++ b/movie_lottery/static/js/pages/history.js
@@ -58,6 +58,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const handleOpenModal = async (lotteryId) => {
         const card = document.querySelector(`.gallery-item[data-lottery-id="${lotteryId}"]`);
+        modalElement.dataset.activeLotteryId = lotteryId;
         modal.open();
         try {
             const lotteryData = await movieApi.fetchLotteryDetails(lotteryId);
@@ -95,6 +96,124 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     };
 
+    const activeSearchTimers = new Map();
+
+    const stopPolling = (kinopoiskId) => {
+        const timerId = activeSearchTimers.get(kinopoiskId);
+        if (timerId) {
+            clearTimeout(timerId);
+            activeSearchTimers.delete(kinopoiskId);
+        }
+    };
+
+    const setCardSearching = (card, isSearching) => {
+        card.dataset.searching = isSearching ? 'true' : 'false';
+        card.classList.toggle('is-searching', isSearching);
+        const searchButton = card.querySelector('.search-button');
+        if (searchButton) {
+            searchButton.disabled = isSearching;
+            searchButton.classList.toggle('loading', isSearching);
+            if (isSearching) {
+                searchButton.setAttribute('aria-busy', 'true');
+            } else {
+                searchButton.removeAttribute('aria-busy');
+            }
+        }
+    };
+
+    const handleSearchStatus = (card, status, lotteryId, { initialToast = false } = {}) => {
+        if (!status || !status.status) {
+            setCardSearching(card, false);
+            return false;
+        }
+
+        const state = status.status;
+        if (state === 'queued' || state === 'running') {
+            if (initialToast) {
+                showToast(status.message || 'Поиск magnet-ссылки запущен.', 'info');
+            }
+            return true;
+        }
+
+        stopPolling(card.dataset.kinopoiskId);
+        setCardSearching(card, false);
+
+        const hasMagnet = Boolean(status.has_magnet && status.magnet_link);
+        card.dataset.hasMagnet = hasMagnet ? 'true' : 'false';
+        card.dataset.magnetLink = hasMagnet ? status.magnet_link : '';
+        toggleDownloadIcon(card, hasMagnet);
+
+        if (hasMagnet) {
+            showToast(status.message || 'Magnet-ссылка найдена.', 'success');
+            if (window.torrentUpdater && typeof window.torrentUpdater.updateUi === 'function') {
+                window.torrentUpdater.updateUi();
+            }
+            if (
+                modalElement.style.display === 'flex'
+                && modalElement.dataset.activeLotteryId === lotteryId
+            ) {
+                handleOpenModal(lotteryId);
+            }
+        } else if (state === 'not_found') {
+            showToast(status.message || 'Подходящая magnet-ссылка не найдена.', 'warning');
+        } else if (state === 'failed') {
+            showToast(status.message || 'Ошибка при поиске magnet.', 'error');
+        } else {
+            showToast(status.message || 'Поиск завершен.', 'info');
+        }
+
+        return false;
+    };
+
+    const pollSearchStatus = (card, kinopoiskId, lotteryId) => {
+        const scheduleNext = () => {
+            const timerId = setTimeout(async () => {
+                try {
+                    const status = await movieApi.fetchMagnetSearchStatus(kinopoiskId);
+                    const shouldContinue = handleSearchStatus(card, status, lotteryId);
+                    if (shouldContinue) {
+                        scheduleNext();
+                    }
+                } catch (error) {
+                    stopPolling(kinopoiskId);
+                    setCardSearching(card, false);
+                    showToast(error.message, 'error');
+                }
+            }, 2000);
+            activeSearchTimers.set(kinopoiskId, timerId);
+        };
+
+        stopPolling(kinopoiskId);
+        scheduleNext();
+    };
+
+    const triggerMagnetSearch = async (card) => {
+        const { kinopoiskId, movieName, movieYear, lotteryId } = card.dataset;
+        if (!kinopoiskId) {
+            showToast('Для фильма не указан Kinopoisk ID.', 'error');
+            return;
+        }
+
+        if (card.dataset.searching === 'true' || activeSearchTimers.has(kinopoiskId)) {
+            showToast('Поиск magnet уже выполняется.', 'info');
+            return;
+        }
+
+        const query = `${(movieName || '').trim()} ${movieYear || ''}`.trim();
+        setCardSearching(card, true);
+
+        try {
+            const status = await movieApi.startMagnetSearch(kinopoiskId, { query, title: movieName, year: movieYear });
+            const shouldContinue = handleSearchStatus(card, status, lotteryId, { initialToast: true });
+            if (shouldContinue) {
+                pollSearchStatus(card, kinopoiskId, lotteryId);
+            }
+        } catch (error) {
+            setCardSearching(card, false);
+            showToast(error.message, 'error');
+        }
+    };
+
     gallery.addEventListener('click', (event) => {
         const card = event.target.closest('.gallery-item');
         if (!card) return;
@@ -110,8 +229,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     showToast(data.message, data.success ? 'success' : 'error');
                 });
             } else if (button.classList.contains('search-button')) {
-                const query = encodeURIComponent(`${movieName.trim()} ${movieYear || ''}`.trim());
-                window.open(`https://rutracker.org/forum/tracker.php?nm=${query}`, '_blank');
+                triggerMagnetSearch(card);
             } else if (button.classList.contains('download-button')) {
                 if (hasMagnet === 'true' && kinopoiskId) {
                     torrentApi.startDownloadByKpId(kinopoiskId).then(data => showToast(data.message, data.success ? 'success' : 'error'));
@@ -129,6 +247,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     document.querySelectorAll('.date-badge').forEach(badge => {
         badge.textContent = formatDate(badge.dataset.date);
+    });
+
+    window.addEventListener('beforeunload', () => {
+        activeSearchTimers.forEach(timerId => clearTimeout(timerId));
+        activeSearchTimers.clear();
     });
 
     if (window.torrentUpdater) {

--- a/movie_lottery/static/js/pages/library.js
+++ b/movie_lottery/static/js/pages/library.js
@@ -74,6 +74,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const handleOpenModal = (card) => {
         const movieData = getMovieDataFromCard(card);
+        modalElement.dataset.activeCardId = card.dataset.movieId || '';
         modal.open();
         modal.renderLibraryModal(movieData, {
             onSaveMagnet: async (kinopoiskId, magnetLink) => {
@@ -103,6 +104,126 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     };
 
+    const activeSearchTimers = new Map();
+
+    const stopPolling = (kinopoiskId) => {
+        const timerId = activeSearchTimers.get(kinopoiskId);
+        if (timerId) {
+            clearTimeout(timerId);
+            activeSearchTimers.delete(kinopoiskId);
+        }
+    };
+
+    const setCardSearching = (card, isSearching) => {
+        card.dataset.searching = isSearching ? 'true' : 'false';
+        card.classList.toggle('is-searching', isSearching);
+        const searchButton = card.querySelector('.search-button');
+        if (searchButton) {
+            searchButton.disabled = isSearching;
+            searchButton.classList.toggle('loading', isSearching);
+            if (isSearching) {
+                searchButton.setAttribute('aria-busy', 'true');
+            } else {
+                searchButton.removeAttribute('aria-busy');
+            }
+        }
+    };
+
+    const handleSearchStatus = (card, status, { initialToast = false } = {}) => {
+        if (!status || !status.status) {
+            setCardSearching(card, false);
+            return false;
+        }
+
+        const state = status.status;
+        if (state === 'queued' || state === 'running') {
+            if (initialToast) {
+                showToast(status.message || 'Поиск magnet-ссылки запущен.', 'info');
+            }
+            return true;
+        }
+
+        stopPolling(card.dataset.kinopoiskId);
+        setCardSearching(card, false);
+
+        const hasMagnet = Boolean(status.has_magnet && status.magnet_link);
+        if (hasMagnet) {
+            card.dataset.hasMagnet = 'true';
+            card.dataset.magnetLink = status.magnet_link;
+            toggleDownloadIcon(card, true);
+            showToast(status.message || 'Magnet-ссылка найдена.', 'success');
+            if (window.torrentUpdater && typeof window.torrentUpdater.updateUi === 'function') {
+                window.torrentUpdater.updateUi();
+            }
+            if (modalElement.style.display === 'flex' && modalElement.dataset.activeCardId === (card.dataset.movieId || '')) {
+                handleOpenModal(card);
+            }
+        } else {
+            card.dataset.hasMagnet = 'false';
+            card.dataset.magnetLink = '';
+            toggleDownloadIcon(card, false);
+
+            if (state === 'not_found') {
+                showToast(status.message || 'Подходящая magnet-ссылка не найдена.', 'warning');
+            } else if (state === 'failed') {
+                showToast(status.message || 'Ошибка при поиске magnet.', 'error');
+            } else {
+                showToast(status.message || 'Поиск завершен без результата.', 'info');
+            }
+        }
+
+        return false;
+    };
+
+    const pollSearchStatus = (card, kinopoiskId) => {
+        const scheduleNext = () => {
+            const timerId = setTimeout(async () => {
+                try {
+                    const status = await movieApi.fetchMagnetSearchStatus(kinopoiskId);
+                    const shouldContinue = handleSearchStatus(card, status);
+                    if (shouldContinue) {
+                        scheduleNext();
+                    }
+                } catch (error) {
+                    stopPolling(kinopoiskId);
+                    setCardSearching(card, false);
+                    showToast(error.message, 'error');
+                }
+            }, 2000);
+            activeSearchTimers.set(kinopoiskId, timerId);
+        };
+
+        stopPolling(kinopoiskId);
+        scheduleNext();
+    };
+
+    const triggerMagnetSearch = async (card) => {
+        const { kinopoiskId, movieName, movieYear } = card.dataset;
+        if (!kinopoiskId) {
+            showToast('Для фильма не указан Kinopoisk ID.', 'error');
+            return;
+        }
+
+        if (card.dataset.searching === 'true' || activeSearchTimers.has(kinopoiskId)) {
+            showToast('Поиск magnet уже выполняется.', 'info');
+            return;
+        }
+
+        const query = `${(movieName || '').trim()} ${movieYear || ''}`.trim();
+        setCardSearching(card, true);
+
+        try {
+            const status = await movieApi.startMagnetSearch(kinopoiskId, { query, title: movieName, year: movieYear });
+            const shouldContinue = handleSearchStatus(card, status, { initialToast: true });
+            if (shouldContinue) {
+                pollSearchStatus(card, kinopoiskId);
+            }
+        } catch (error) {
+            setCardSearching(card, false);
+            showToast(error.message, 'error');
+        }
+    };
+
     gallery.addEventListener('click', (event) => {
         const card = event.target.closest('.gallery-item');
         if (!card) return;
@@ -118,8 +239,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     showToast(data.message, data.success ? 'success' : 'error');
                 });
             } else if (button.classList.contains('search-button')) {
-                const query = encodeURIComponent(`${movieName.trim()} ${movieYear || ''}`.trim());
-                window.open(`https://rutracker.org/forum/tracker.php?nm=${query}`, '_blank');
+                triggerMagnetSearch(card);
             } else if (button.classList.contains('download-button')) {
                 if (hasMagnet === 'true' && kinopoiskId) {
                     torrentApi.startLibraryDownload(movieId).then(data => showToast(data.message, data.success ? 'success' : 'error'));
@@ -135,6 +255,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     document.querySelectorAll('.date-badge').forEach(badge => {
         badge.textContent = formatDate(badge.dataset.date);
+    });
+
+    window.addEventListener('beforeunload', () => {
+        activeSearchTimers.forEach(timerId => clearTimeout(timerId));
+        activeSearchTimers.clear();
     });
 
     if (window.torrentUpdater) {

--- a/movie_lottery/utils/magnet_search.py
+++ b/movie_lottery/utils/magnet_search.py
@@ -1,0 +1,303 @@
+"""Utilities for performing background magnet link searches."""
+from __future__ import annotations
+
+import logging
+from concurrent.futures import Future, ThreadPoolExecutor
+from threading import Lock
+from typing import Any, Dict, Optional
+from urllib.parse import quote_plus
+
+import requests
+from flask import current_app, has_app_context
+
+from .. import db
+from ..models import MovieIdentifier
+
+DEFAULT_SEARCH_URL = "https://apibay.org/q.php?q={query}"
+DEFAULT_TRACKERS = (
+    "udp://tracker.opentrackr.org:1337/announce",
+    "udp://tracker.coppersurfer.tk:6969/announce",
+    "udp://tracker.leechers-paradise.org:6969/announce",
+    "udp://9.rarbg.to:2710/announce",
+    "udp://9.rarbg.me:2710/announce",
+)
+
+_logger = logging.getLogger(__name__)
+
+_search_executor = ThreadPoolExecutor(max_workers=3)
+_tasks: Dict[int, Dict[str, Any]] = {}
+_tasks_lock = Lock()
+
+
+def _get_configured_value(key: str, default: Any) -> Any:
+    if has_app_context():
+        return current_app.config.get(key, default)
+    return default
+
+
+def _build_magnet(info_hash: str, name: str, trackers: Optional[Any] = None) -> str:
+    trackers = trackers or _get_configured_value("MAGNET_TRACKERS", DEFAULT_TRACKERS)
+    if isinstance(trackers, str):
+        trackers = [trackers]
+    params = [f"xt=urn:btih:{info_hash}", f"dn={quote_plus(name)}"]
+    for tracker in trackers or ():
+        if tracker:
+            params.append(f"tr={quote_plus(str(tracker))}")
+    return "magnet:?" + "&".join(params)
+
+
+def _extract_seeders(payload: Dict[str, Any]) -> int:
+    for key in ("seeders", "seeds", "Seeders", "seeders_count", "num_seeders", "seedersCount"):
+        if key in payload:
+            try:
+                return int(payload[key])
+            except (TypeError, ValueError):
+                continue
+    return 0
+
+
+def _extract_info_hash(payload: Dict[str, Any]) -> Optional[str]:
+    for key in ("info_hash", "hash", "infoHash", "torrent_hash"):
+        value = payload.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def search_best_magnet(title: str, *, session: Optional[requests.Session] = None, timeout: int = 15) -> Optional[str]:
+    """Searches for the best magnet link matching the provided title.
+
+    The function fetches results from a configurable tracker search endpoint, filters
+    them by 1080p quality, and returns the magnet link with the highest number of
+    seeders. If nothing suitable is found, ``None`` is returned.
+    """
+
+    query = (title or "").strip()
+    if not query:
+        return None
+
+    session = session or requests.Session()
+    base_url = _get_configured_value("MAGNET_SEARCH_URL", DEFAULT_SEARCH_URL)
+    try:
+        response = session.get(base_url.format(query=quote_plus(query)), timeout=timeout)
+        response.raise_for_status()
+        try:
+            data = response.json()
+        except ValueError as exc:  # noqa: PERF203 - explicit error message is helpful
+            raise RuntimeError("Ответ трекера не в формате JSON") from exc
+    except requests.RequestException as exc:
+        raise RuntimeError(f"Ошибка запроса к трекеру: {exc}") from exc
+
+    if isinstance(data, dict) and "results" in data:
+        results = data.get("results") or []
+    elif isinstance(data, list):
+        results = data
+    else:
+        results = []
+
+    if not results:
+        return None
+
+    quality_keywords = ("1080p", "1080")
+    filtered: list[Dict[str, Any]] = []
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or item.get("title") or "")
+        lower_name = name.lower()
+        if any(q in lower_name for q in quality_keywords):
+            filtered.append(item)
+
+    candidates = filtered or [item for item in results if isinstance(item, dict)]
+    if not candidates:
+        return None
+
+    candidates.sort(key=_extract_seeders, reverse=True)
+
+    trackers = _get_configured_value("MAGNET_TRACKERS", DEFAULT_TRACKERS)
+    if isinstance(trackers, str):
+        trackers = [trackers]
+
+    for item in candidates:
+        magnet = item.get("magnet") or item.get("magnet_link") or item.get("magnetLink")
+        if magnet and isinstance(magnet, str):
+            return magnet
+        info_hash = _extract_info_hash(item)
+        name = str(item.get("name") or item.get("title") or query)
+        if info_hash:
+            return _build_magnet(info_hash, name, trackers)
+    return None
+
+
+def _store_identifier(kinopoisk_id: int, magnet_link: str) -> None:
+    identifier = MovieIdentifier.query.get(kinopoisk_id)
+    if identifier:
+        identifier.magnet_link = magnet_link
+    else:
+        identifier = MovieIdentifier(kinopoisk_id=kinopoisk_id, magnet_link=magnet_link)
+        db.session.add(identifier)
+
+
+def _search_worker(app, kinopoisk_id: int, query: str) -> Dict[str, Any]:
+    with app.app_context():
+        result: Dict[str, Any] = {
+            "status": "running",
+            "kinopoisk_id": kinopoisk_id,
+            "query": query,
+            "has_magnet": False,
+            "magnet_link": "",
+        }
+        try:
+            magnet_link = search_best_magnet(query)
+            if magnet_link:
+                _store_identifier(kinopoisk_id, magnet_link)
+                db.session.commit()
+                result.update(
+                    {
+                        "status": "completed",
+                        "has_magnet": True,
+                        "magnet_link": magnet_link,
+                        "message": "Magnet-ссылка успешно найдена.",
+                    }
+                )
+            else:
+                db.session.commit()
+                result.update(
+                    {
+                        "status": "not_found",
+                        "message": "Подходящая magnet-ссылка не найдена.",
+                    }
+                )
+        except Exception as exc:  # noqa: BLE001 - логируем и возвращаем ошибку
+            db.session.rollback()
+            _logger.exception("Ошибка поиска magnet для %s", kinopoisk_id)
+            result.update(
+                {
+                    "status": "failed",
+                    "message": f"Ошибка при поиске magnet: {exc}",
+                    "error": str(exc),
+                }
+            )
+        return result
+
+
+def _set_task_entry(kinopoisk_id: int, future: Future, query: str) -> None:
+    with _tasks_lock:
+        _tasks[kinopoisk_id] = {"future": future, "query": query, "result": None}
+
+
+def _update_task_result(kinopoisk_id: int, future: Future) -> None:
+    try:
+        result = future.result()
+    except Exception as exc:  # noqa: BLE001 - фиксируем в результатах
+        result = {
+            "status": "failed",
+            "kinopoisk_id": kinopoisk_id,
+            "has_magnet": False,
+            "magnet_link": "",
+            "message": f"Ошибка при поиске magnet: {exc}",
+            "error": str(exc),
+        }
+    with _tasks_lock:
+        entry = _tasks.get(kinopoisk_id)
+        if entry is not None:
+            entry["result"] = result
+
+
+def _get_task_entry(kinopoisk_id: int) -> Optional[Dict[str, Any]]:
+    with _tasks_lock:
+        return _tasks.get(kinopoisk_id)
+
+
+def start_background_search(kinopoisk_id: int, query: str, *, force: bool = False) -> Dict[str, Any]:
+    query = (query or "").strip()
+    if not query:
+        return {
+            "status": "failed",
+            "kinopoisk_id": kinopoisk_id,
+            "has_magnet": False,
+            "magnet_link": "",
+            "message": "Не указан поисковый запрос.",
+        }
+
+    identifier = MovieIdentifier.query.get(kinopoisk_id)
+    if identifier and identifier.magnet_link and not force:
+        return {
+            "status": "completed",
+            "kinopoisk_id": kinopoisk_id,
+            "has_magnet": True,
+            "magnet_link": identifier.magnet_link,
+            "message": "Magnet-ссылка уже сохранена.",
+        }
+
+    entry = _get_task_entry(kinopoisk_id)
+    if entry:
+        future = entry.get("future")
+        if future and not future.done() and not force:
+            return {
+                "status": "running",
+                "kinopoisk_id": kinopoisk_id,
+                "has_magnet": False,
+                "magnet_link": "",
+                "message": "Поиск уже выполняется.",
+            }
+
+    app = current_app._get_current_object()
+    future = _search_executor.submit(_search_worker, app, kinopoisk_id, query)
+    future.add_done_callback(lambda f, kp_id=kinopoisk_id: _update_task_result(kp_id, f))
+    _set_task_entry(kinopoisk_id, future, query)
+    return {
+        "status": "queued",
+        "kinopoisk_id": kinopoisk_id,
+        "has_magnet": False,
+        "magnet_link": "",
+        "message": "Поиск magnet-ссылки запущен.",
+    }
+
+
+def get_search_status(kinopoisk_id: int) -> Dict[str, Any]:
+    entry = _get_task_entry(kinopoisk_id)
+    if entry:
+        future: Future = entry.get("future")
+        if future and not future.done():
+            return {
+                "status": "running",
+                "kinopoisk_id": kinopoisk_id,
+                "has_magnet": False,
+                "magnet_link": "",
+                "message": "Поиск выполняется.",
+            }
+        result = entry.get("result")
+        if result is None and future:
+            try:
+                result = future.result()
+            except Exception as exc:  # noqa: BLE001 - переводим в понятный ответ
+                result = {
+                    "status": "failed",
+                    "kinopoisk_id": kinopoisk_id,
+                    "has_magnet": False,
+                    "magnet_link": "",
+                    "message": f"Ошибка при поиске magnet: {exc}",
+                    "error": str(exc),
+                }
+            entry["result"] = result
+        if result:
+            return result
+
+    identifier = MovieIdentifier.query.get(kinopoisk_id)
+    if identifier and identifier.magnet_link:
+        return {
+            "status": "completed",
+            "kinopoisk_id": kinopoisk_id,
+            "has_magnet": True,
+            "magnet_link": identifier.magnet_link,
+            "message": "Magnet-ссылка сохранена.",
+        }
+
+    return {
+        "status": "idle",
+        "kinopoisk_id": kinopoisk_id,
+        "has_magnet": False,
+        "magnet_link": "",
+        "message": "Поиск magnet еще не запускался.",
+    }


### PR DESCRIPTION
## Summary
- add a reusable magnet search utility that queries trackers, filters 1080p results and stores the best link asynchronously
- expose a background magnet search API, trigger it when movies are created or saved, and surface the task status
- update library and history pages to call the new API, show progress, and refresh cards when magnet links arrive

## Testing
- python -m compileall movie_lottery
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d158ce58448328b2b44bbc79561e17