### PR TITLE
Handle waiting lottery modal with share actions

### DIFF
--- a/movie_lottery/static/js/pages/history.js
+++ b/movie_lottery/static/js/pages/history.js
@@ -89,7 +89,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     }
                 });
             } else {
-                modal.renderError('Информация о победителе еще не доступна.');
+                modal.renderWaitingModal(lotteryData);
             }
         } catch (error) {
             modal.renderError(error.message);
@@ -238,10 +238,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     handleOpenModal(lotteryId);
                 }
             }
-        } else if (!card.classList.contains('waiting-card')) {
+        } else if (lotteryId) {
             handleOpenModal(lotteryId);
-        } else {
-            showToast('Эта лотерея еще не разыграна.', 'info');
         }
     });
 


### PR DESCRIPTION
## Summary
- allow history cards to always fetch lottery details and display a waiting state when the winner is unavailable
- extend the history modal with a waiting layout that shows the play link alongside copy and Telegram share actions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d15e4e4c9c832893136453de2444d2