### PR TITLE
Add client-side caching for background rotator

### DIFF
--- a/movie_lottery/static/js/background.js
+++ b/movie_lottery/static/js/background.js
@@ -1,6 +1,30 @@
 // static/js/background.js
 
 import { loadBackgroundInBatches } from './utils/backgroundLoader.js';
+import { clearCachedBackground, loadCachedBackground } from './utils/backgroundCache.js';
+
+function computeBackgroundVersion(photos) {
+    if (!Array.isArray(photos) || photos.length === 0) {
+        return 'empty';
+    }
+
+    const hashSource = photos.map((photo) => [
+        photo.poster_url,
+        photo.pos_top,
+        photo.pos_left,
+        photo.rotation,
+        photo.z_index,
+    ]);
+
+    const serialized = JSON.stringify(hashSource);
+    let hash = 0;
+
+    for (let index = 0; index < serialized.length; index += 1) {
+        hash = (hash * 31 + serialized.charCodeAt(index)) >>> 0;
+    }
+
+    return `${photos.length}:${hash}`;
+}
 
 document.addEventListener('DOMContentLoaded', () => {
     const rotator = document.querySelector('.background-rotator');
@@ -8,7 +32,26 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
     }
 
-    if (typeof backgroundPhotos !== 'undefined' && Array.isArray(backgroundPhotos)) {
-        loadBackgroundInBatches(rotator, backgroundPhotos);
+    if (typeof backgroundPhotos === 'undefined' || !Array.isArray(backgroundPhotos)) {
+        return;
     }
+
+    const cacheVersion = computeBackgroundVersion(backgroundPhotos);
+    const cachedBackground = loadCachedBackground(cacheVersion);
+
+    if (cachedBackground && cachedBackground.markup) {
+        rotator.innerHTML = cachedBackground.markup;
+        requestAnimationFrame(() => {
+            rotator.querySelectorAll('.bg-image').forEach((element) => {
+                element.classList.add('is-loaded');
+            });
+        });
+        return;
+    }
+
+    clearCachedBackground();
+
+    loadBackgroundInBatches(rotator, backgroundPhotos, {
+        cacheVersion,
+    });
 });

--- a/movie_lottery/static/js/utils/backgroundCache.js
+++ b/movie_lottery/static/js/utils/backgroundCache.js
@@ -1,0 +1,75 @@
+const STORAGE_KEY = 'movie_lottery_background_cache';
+
+function getSessionStorage() {
+    try {
+        if (typeof window === 'undefined' || !window.sessionStorage) {
+            return null;
+        }
+        const { sessionStorage } = window;
+        const testKey = `${STORAGE_KEY}_test`;
+        sessionStorage.setItem(testKey, '1');
+        sessionStorage.removeItem(testKey);
+        return sessionStorage;
+    } catch (error) {
+        return null;
+    }
+}
+
+function readCache() {
+    const storage = getSessionStorage();
+    if (!storage) {
+        return null;
+    }
+
+    try {
+        const raw = storage.getItem(STORAGE_KEY);
+        if (!raw) {
+            return null;
+        }
+        return JSON.parse(raw);
+    } catch (error) {
+        return null;
+    }
+}
+
+function writeCache(payload) {
+    const storage = getSessionStorage();
+    if (!storage) {
+        return;
+    }
+
+    try {
+        if (payload === null) {
+            storage.removeItem(STORAGE_KEY);
+            return;
+        }
+
+        storage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    } catch (error) {
+        // Игнорируем ошибки записи (например, переполнение quota)
+    }
+}
+
+export function loadCachedBackground(version) {
+    const cached = readCache();
+    if (!cached || !cached.version || cached.version !== version) {
+        return null;
+    }
+    return cached;
+}
+
+export function saveCachedBackground(data) {
+    if (!data || !data.version) {
+        return;
+    }
+
+    writeCache({
+        ...data,
+        version: data.version,
+        savedAt: Date.now(),
+    });
+}
+
+export function clearCachedBackground() {
+    writeCache(null);
+}

--- a/movie_lottery/static/js/utils/backgroundLoader.js
+++ b/movie_lottery/static/js/utils/backgroundLoader.js
@@ -1,3 +1,5 @@
+import { saveCachedBackground } from './backgroundCache.js';
+
 const DEFAULT_BATCH_SIZE = 4;
 
 function decodeImage(image) {
@@ -91,7 +93,7 @@ export function loadBackgroundInBatches(rotator, photos, options = {}) {
         return Promise.resolve([]);
     }
 
-    const { batchSize = DEFAULT_BATCH_SIZE } = options;
+    const { batchSize = DEFAULT_BATCH_SIZE, cacheVersion } = options;
     let index = 0;
     const tasks = [];
     let resolveCompletion;
@@ -102,7 +104,15 @@ export function loadBackgroundInBatches(rotator, photos, options = {}) {
     rotator.innerHTML = '';
 
     const finalize = () => {
-        Promise.allSettled(tasks).then(resolveCompletion);
+        Promise.allSettled(tasks).then(() => {
+            if (cacheVersion) {
+                saveCachedBackground({
+                    version: cacheVersion,
+                    markup: rotator.innerHTML,
+                });
+            }
+            resolveCompletion();
+        });
     };
 
     const processBatch = (deadline) => {


### PR DESCRIPTION
## Summary
- add a background cache utility that stores markup in sessionStorage keyed by version
- hydrate the background rotator from cache when possible before falling back to batch loading
- persist freshly rendered backgrounds after batch loading finishes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d168e86bc0832881b7e188edb11809