### PR TITLE
Handle SQLite-safe poll migrations

### DIFF
--- a/migrations/versions/6d69901c1251_add_last_interaction_to_library_movie.py
+++ b/migrations/versions/6d69901c1251_add_last_interaction_to_library_movie.py
@@ -8,6 +8,12 @@ from alembic import op
 import sqlalchemy as sa
 
 
+def _column_exists(bind, table_name, column_name):
+    inspector = sa.inspect(bind)
+    columns = [col['name'] for col in inspector.get_columns(table_name)]
+    return column_name in columns
+
+
 # revision identifiers, used by Alembic.
 revision = '6d69901c1251'
 down_revision = 'f3443ff64408'
@@ -16,17 +22,21 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column(
-        'library_movie',
-        sa.Column('last_interaction_at', sa.DateTime(), server_default=sa.func.now(), nullable=False)
-    )
-    op.execute('UPDATE library_movie SET last_interaction_at = added_at')
-    op.alter_column(
-        'library_movie',
-        'last_interaction_at',
-        existing_type=sa.DateTime(),
-        server_default=None
-    )
+    bind = op.get_bind()
+    if not _column_exists(bind, 'library_movie', 'last_interaction_at'):
+        op.add_column(
+            'library_movie',
+            sa.Column('last_interaction_at', sa.DateTime(), server_default=sa.func.now(), nullable=False)
+        )
+        op.execute('UPDATE library_movie SET last_interaction_at = added_at')
+
+    if bind.dialect.name != 'sqlite':
+        op.alter_column(
+            'library_movie',
+            'last_interaction_at',
+            existing_type=sa.DateTime(),
+            server_default=None
+        )
 
 
 def downgrade():


### PR DESCRIPTION
## Summary
- guard the `library_movie.last_interaction_at` migration so it skips adding the column when it already exists
- avoid dropping defaults on SQLite while still allowing PostgreSQL to remove the server default after backfilling

## Testing
- `flask db upgrade`
- `flask db history`
- `sqlite3 instance/lottery.db ".tables"`
- `python - <<'PY' ...` (create poll via API)
- `python - <<'PY' ...` (run cleanup_expired_polls)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691802bcb8148328a3af2f48fcb385c8)